### PR TITLE
Separate crates used only for examples into dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ documentation = "https://docs.rs/pkgsrc"
 edition = "2018"
 
 [dependencies]
-ar = "0.7.0"
-flate2 = "1.0.11"
 glob = "0.3.0"
+unindent = "0.1.3"
+
+[dev-dependencies]
+flate2 = "1.0.11"
 regex = "1.3"
 structopt = "0.3"
 tar = "0.4"
-unindent = "0.1.3"


### PR DESCRIPTION
This reduces compile time of applications using this crate.

ar has been deleted since it doesn't seem to be used anywhere.